### PR TITLE
[Feat] chatgpt api 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'io.github.flashvayne:chatgpt-spring-boot-starter:1.0.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/_v3r/project/flask/service/FlaskService.java
+++ b/src/main/java/_v3r/project/flask/service/FlaskService.java
@@ -6,7 +6,7 @@ import _v3r.project.common.apiResponse.ErrorCode;
 import _v3r.project.common.exception.EverException;
 import _v3r.project.morpheme.dto.response.MorphemeResponse;
 import _v3r.project.prompt.domain.Prompt;
-import _v3r.project.prompt.dto.PromptRequest;
+import _v3r.project.prompt.dto.request.PromptRequest;
 import _v3r.project.flask.dto.FlaskResponse;
 import _v3r.project.prompt.repository.PromptRepository;
 import java.util.HashMap;

--- a/src/main/java/_v3r/project/prompt/controller/ChatController.java
+++ b/src/main/java/_v3r/project/prompt/controller/ChatController.java
@@ -1,7 +1,7 @@
 package _v3r.project.prompt.controller;
 
 import _v3r.project.prompt.dto.request.ChatRequest;
-import _v3r.project.prompt.dto.response.ChatResponse;
+import _v3r.project.prompt.dto.response.ImageResponse;
 import _v3r.project.prompt.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,8 +15,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatController {
     private final ChatService chatService;
     @PostMapping("")
-    public ChatResponse chat(@RequestBody ChatRequest request) {
+    public String chat(@RequestBody ChatRequest request) {
         return chatService.getChatResponse(request.promptContent());
     }
+
+    @PostMapping("/fish-image")
+    public ImageResponse generateFishImage(@RequestBody ChatRequest request) {
+        return chatService.generateImage(request.promptContent());
+    }
+
+
 
 }

--- a/src/main/java/_v3r/project/prompt/controller/ChatController.java
+++ b/src/main/java/_v3r/project/prompt/controller/ChatController.java
@@ -1,0 +1,22 @@
+package _v3r.project.prompt.controller;
+
+import _v3r.project.prompt.dto.request.ChatRequest;
+import _v3r.project.prompt.dto.response.ChatResponse;
+import _v3r.project.prompt.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat")
+public class ChatController {
+    private final ChatService chatService;
+    @PostMapping("")
+    public ChatResponse chat(@RequestBody ChatRequest request) {
+        return chatService.getChatResponse(request.promptContent());
+    }
+
+}

--- a/src/main/java/_v3r/project/prompt/controller/ChatController.java
+++ b/src/main/java/_v3r/project/prompt/controller/ChatController.java
@@ -1,5 +1,6 @@
 package _v3r.project.prompt.controller;
 
+import _v3r.project.prompt.domain.enumtype.Paints;
 import _v3r.project.prompt.dto.request.ChatRequest;
 import _v3r.project.prompt.dto.response.ImageResponse;
 import _v3r.project.prompt.service.ChatService;
@@ -7,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,10 +22,14 @@ public class ChatController {
     }
 
     @PostMapping("/fish-image")
-    public ImageResponse generateFishImage(@RequestBody ChatRequest request) {
-        return chatService.generateImage(request.promptContent());
+    public ImageResponse generateFishImage(@RequestParam(name = "paints") Paints paints, @RequestBody ChatRequest request) {
+        return chatService.generateFishImage(paints.어해도,request.promptContent());
     }
 
+    @PostMapping("/mountain-image")
+    public ImageResponse generateMountainImage(@RequestParam(name = "paints") Paints paints, @RequestBody ChatRequest request) {
+        return chatService.generateMountainImage(paints.산수도,request.promptContent());
+    }
 
 
 }

--- a/src/main/java/_v3r/project/prompt/controller/PromptController.java
+++ b/src/main/java/_v3r/project/prompt/controller/PromptController.java
@@ -1,8 +1,8 @@
 package _v3r.project.prompt.controller;
 
 import _v3r.project.common.apiResponse.CustomApiResponse;
-import _v3r.project.prompt.dto.PromptRequest;
-import _v3r.project.prompt.dto.PromptResponse;
+import _v3r.project.prompt.dto.request.PromptRequest;
+import _v3r.project.prompt.dto.response.PromptResponse;
 import _v3r.project.prompt.service.PromptService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/_v3r/project/prompt/domain/enumtype/Paints.java
+++ b/src/main/java/_v3r/project/prompt/domain/enumtype/Paints.java
@@ -1,0 +1,5 @@
+package _v3r.project.prompt.domain.enumtype;
+
+public enum Paints {
+    어해도,산수도
+}

--- a/src/main/java/_v3r/project/prompt/dto/request/ChatRequest.java
+++ b/src/main/java/_v3r/project/prompt/dto/request/ChatRequest.java
@@ -1,0 +1,4 @@
+package _v3r.project.prompt.dto.request;
+
+public record ChatRequest(String promptContent) {}
+

--- a/src/main/java/_v3r/project/prompt/dto/request/PromptRequest.java
+++ b/src/main/java/_v3r/project/prompt/dto/request/PromptRequest.java
@@ -1,4 +1,4 @@
-package _v3r.project.prompt.dto;
+package _v3r.project.prompt.dto.request;
 
 import _v3r.project.prompt.domain.Prompt;
 import _v3r.project.user.domain.User;

--- a/src/main/java/_v3r/project/prompt/dto/response/ChatResponse.java
+++ b/src/main/java/_v3r/project/prompt/dto/response/ChatResponse.java
@@ -1,0 +1,17 @@
+package _v3r.project.prompt.dto.response;
+
+import java.util.List;
+
+public record ChatResponse(
+        String id,
+        String object,
+        long created,
+        String model,
+        List<Choice> choices
+) {
+    public record Choice(
+            String text,
+            int index,
+            String finish_reason
+    ) {}
+}

--- a/src/main/java/_v3r/project/prompt/dto/response/ImageResponse.java
+++ b/src/main/java/_v3r/project/prompt/dto/response/ImageResponse.java
@@ -1,0 +1,8 @@
+package _v3r.project.prompt.dto.response;
+
+import java.util.List;
+
+public record ImageResponse(List<ImageData> data) {
+    public record ImageData(String url) {}
+
+}

--- a/src/main/java/_v3r/project/prompt/dto/response/ImageResponse.java
+++ b/src/main/java/_v3r/project/prompt/dto/response/ImageResponse.java
@@ -1,8 +1,9 @@
 package _v3r.project.prompt.dto.response;
 
+import _v3r.project.prompt.domain.enumtype.Paints;
 import java.util.List;
 
-public record ImageResponse(List<ImageData> data) {
+public record ImageResponse(Paints paints, List<ImageData> data) {
     public record ImageData(String url) {}
 
 }

--- a/src/main/java/_v3r/project/prompt/dto/response/PromptResponse.java
+++ b/src/main/java/_v3r/project/prompt/dto/response/PromptResponse.java
@@ -1,4 +1,4 @@
-package _v3r.project.prompt.dto;
+package _v3r.project.prompt.dto.response;
 
 import _v3r.project.prompt.domain.Prompt;
 import lombok.Builder;

--- a/src/main/java/_v3r/project/prompt/service/ChatService.java
+++ b/src/main/java/_v3r/project/prompt/service/ChatService.java
@@ -1,6 +1,7 @@
 package _v3r.project.prompt.service;
 
 import _v3r.project.prompt.dto.response.ChatResponse;
+import _v3r.project.prompt.dto.response.ImageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
@@ -18,7 +19,7 @@ public class ChatService {
     @Value("${chatgpt.api-key}")
     private String apiKey;
 
-    public ChatResponse getChatResponse(String promptContent) {
+    public String getChatResponse(String promptContent) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth(apiKey);
@@ -26,7 +27,7 @@ public class ChatService {
         Map<String, Object> body = Map.of(
                 "model", "gpt-3.5-turbo-instruct",
                 "prompt", promptContent,
-                "max_tokens", 100
+                "max_tokens", 1000
         );
 
         HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
@@ -37,6 +38,43 @@ public class ChatService {
                 ChatResponse.class
         );
 
-        return response.getBody();  // ✅ 전체 구조 반환
+        return response.getBody().choices().get(0).text().trim();
     }
+
+    public ImageResponse generateImage(String promptContent) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey);
+
+
+        String styledPrompt = "Generate an artwork in the 어해도 (Korean Minhwa) style. "
+                + "A traditional Korean Minhwa-style painting featuring seven freshwater fish of various sizes (carp, catfish, trout) arranged in a vertical, "
+                + "flat composition with no perspective. The fish are calmly floating in pale water among soft, ink-brushed aquatic plants. On the left side,"
+                + " a large natural rock is depicted with red flowers (resembling Chinese lantern flowers or bleeding hearts) blooming from its cracks."
+                + " The painting uses soft, muted traditional colors like grey, brown, and pale yellow for the fish, with a light grayish background. "
+                + "A splash of red from the flowers adds contrast."
+                + " The brushwork is delicate, the lines are sharp without any ink bleeding, evoking a serene, still atmosphere where nature and life coexist harmoniously in stillness. "
+                + "The painting features vivid, saturated traditional" + promptContent;
+
+
+
+
+        Map<String, Object> body = Map.of(
+                "model","dall-e-3",
+                "prompt", styledPrompt,
+                "n", 1,
+                "size", "1024x1024"
+        );
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<ImageResponse> response = restTemplate.postForEntity(
+                "https://api.openai.com/v1/images/generations",
+                request,
+                ImageResponse.class
+        );
+
+        return response.getBody();
+    }
+
 }

--- a/src/main/java/_v3r/project/prompt/service/ChatService.java
+++ b/src/main/java/_v3r/project/prompt/service/ChatService.java
@@ -1,0 +1,42 @@
+package _v3r.project.prompt.service;
+
+import _v3r.project.prompt.dto.response.ChatResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${chatgpt.api-key}")
+    private String apiKey;
+
+    public ChatResponse getChatResponse(String promptContent) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey);
+
+        Map<String, Object> body = Map.of(
+                "model", "gpt-3.5-turbo-instruct",
+                "prompt", promptContent,
+                "max_tokens", 100
+        );
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<ChatResponse> response = restTemplate.postForEntity(
+                "https://api.openai.com/v1/completions",
+                request,
+                ChatResponse.class
+        );
+
+        return response.getBody();  // ✅ 전체 구조 반환
+    }
+}

--- a/src/main/java/_v3r/project/prompt/service/ChatService.java
+++ b/src/main/java/_v3r/project/prompt/service/ChatService.java
@@ -1,5 +1,6 @@
 package _v3r.project.prompt.service;
 
+import _v3r.project.prompt.domain.enumtype.Paints;
 import _v3r.project.prompt.dto.response.ChatResponse;
 import _v3r.project.prompt.dto.response.ImageResponse;
 import lombok.RequiredArgsConstructor;
@@ -41,11 +42,11 @@ public class ChatService {
         return response.getBody().choices().get(0).text().trim();
     }
 
-    public ImageResponse generateImage(String promptContent) {
+    //TODO 어해도 인지 검증 필요
+    public ImageResponse generateFishImage(Paints paints,String promptContent) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth(apiKey);
-
 
         String styledPrompt = "Generate an artwork in the 어해도 (Korean Minhwa) style. "
                 + "A traditional Korean Minhwa-style painting featuring seven freshwater fish of various sizes (carp, catfish, trout) arranged in a vertical, "
@@ -56,6 +57,32 @@ public class ChatService {
                 + " The brushwork is delicate, the lines are sharp without any ink bleeding, evoking a serene, still atmosphere where nature and life coexist harmoniously in stillness. "
                 + "The painting features vivid, saturated traditional" + promptContent;
 
+        Map<String, Object> body = Map.of(
+                "model","dall-e-3",
+                "prompt", styledPrompt,
+                "n", 1,
+                "size", "1024x1024"
+        );
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<ImageResponse> response = restTemplate.postForEntity(
+                "https://api.openai.com/v1/images/generations",
+                request,
+                ImageResponse.class
+        );
+
+        return response.getBody();
+    }
+
+    public ImageResponse generateMountainImage(Paints paints,String promptContent) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey);
+
+        String styledPrompt = "Generate an artwork in the style of traditional Korean ink landscape painting (산수화, 山水畫). "
+                + "The scene should include: " + promptContent + ". "
+                + "Use ink wash techniques only, with soft gradients of black, gray, and a warm yellowed paper texture to simulate aged hanji.";
 
 
 

--- a/src/main/java/_v3r/project/prompt/service/PromptService.java
+++ b/src/main/java/_v3r/project/prompt/service/PromptService.java
@@ -1,12 +1,11 @@
 package _v3r.project.prompt.service;
 
-import _v3r.project.common.annotation.AuthUser;
 import _v3r.project.common.apiResponse.ErrorCode;
 import _v3r.project.common.exception.EverException;
 import _v3r.project.flask.service.FlaskService;
 import _v3r.project.prompt.domain.Prompt;
-import _v3r.project.prompt.dto.PromptRequest;
-import _v3r.project.prompt.dto.PromptResponse;
+import _v3r.project.prompt.dto.request.PromptRequest;
+import _v3r.project.prompt.dto.response.PromptResponse;
 import _v3r.project.prompt.repository.PromptRepository;
 import _v3r.project.user.domain.User;
 import _v3r.project.user.repository.UserRepository;


### PR DESCRIPTION

이미지 생성 api 연결 
![image](https://github.com/user-attachments/assets/7712db39-d8bc-44fa-a332-60a7bf0e6f1d)
---------
![image](https://github.com/user-attachments/assets/b52247b7-7481-4943-a6fc-46d123c55608)
--------
<비고사항>
후에 이미지 카테고리 추가되면 enum에 추가해 api 추가분리할 예정